### PR TITLE
fixed namespace bug, moved Employee to api namespace

### DIFF
--- a/api/Data/apiContext.cs
+++ b/api/Data/apiContext.cs
@@ -1,0 +1,19 @@
+﻿#nullable disable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+
+namespace api.Data
+{
+    public class ApiContext : DbContext
+    {
+        public ApiContext (DbContextOptions<ApiContext> options)
+            : base(options)
+        {
+        }
+
+        public DbSet<Employee> Employee { get; set; }
+    }
+}

--- a/api/EmployeesController.cs
+++ b/api/EmployeesController.cs
@@ -1,0 +1,108 @@
+﻿#nullable disable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using api.Data;
+
+namespace api
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class EmployeesController : ControllerBase
+    {
+        private readonly ApiContext _context;
+
+        public EmployeesController(ApiContext context)
+        {
+            _context = context;
+        }
+
+        // GET: api/Employees
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<Employee>>> GetEmployee()
+        {
+            return await _context.Employee.ToListAsync();
+        }
+
+        // GET: api/Employees/5
+        [HttpGet("{id}")]
+        public async Task<ActionResult<Employee>> GetEmployee(int id)
+        {
+            var employee = await _context.Employee.FindAsync(id);
+
+            if (employee == null)
+            {
+                return NotFound();
+            }
+
+            return employee;
+        }
+
+        // PUT: api/Employees/5
+        // To protect from overposting attacks, see https://go.microsoft.com/fwlink/?linkid=2123754
+        [HttpPut("{id}")]
+        public async Task<IActionResult> PutEmployee(int id, Employee employee)
+        {
+            if (id != employee.Id)
+            {
+                return BadRequest();
+            }
+
+            _context.Entry(employee).State = EntityState.Modified;
+
+            try
+            {
+                await _context.SaveChangesAsync();
+            }
+            catch (DbUpdateConcurrencyException)
+            {
+                if (!EmployeeExists(id))
+                {
+                    return NotFound();
+                }
+                else
+                {
+                    throw;
+                }
+            }
+
+            return NoContent();
+        }
+
+        // POST: api/Employees
+        // To protect from overposting attacks, see https://go.microsoft.com/fwlink/?linkid=2123754
+        [HttpPost]
+        public async Task<ActionResult<Employee>> PostEmployee(Employee employee)
+        {
+            _context.Employee.Add(employee);
+            await _context.SaveChangesAsync();
+
+            return CreatedAtAction("GetEmployee", new { id = employee.Id }, employee);
+        }
+
+        // DELETE: api/Employees/5
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> DeleteEmployee(int id)
+        {
+            var employee = await _context.Employee.FindAsync(id);
+            if (employee == null)
+            {
+                return NotFound();
+            }
+
+            _context.Employee.Remove(employee);
+            await _context.SaveChangesAsync();
+
+            return NoContent();
+        }
+
+        private bool EmployeeExists(int id)
+        {
+            return _context.Employee.Any(e => e.Id == id);
+        }
+    }
+}

--- a/api/Models/Employee.cs
+++ b/api/Models/Employee.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace nunit_tests
+namespace api
 {
     public class Employee
     {

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -1,4 +1,10 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using api.Data;
 var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddDbContext<ApiContext>(options =>
+    options.UseSqlServer(builder.Configuration.GetConnectionString("apiContext")));
 
 // Add services to the container.
 

--- a/api/Properties/serviceDependencies.json
+++ b/api/Properties/serviceDependencies.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "mssql1": {
+      "type": "mssql",
+      "connectionId": "ConnectionStrings:apiContext"
+    }
+  }
+}

--- a/api/Properties/serviceDependencies.local.json
+++ b/api/Properties/serviceDependencies.local.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "mssql1": {
+      "type": "mssql.local",
+      "connectionId": "ConnectionStrings:apiContext"
+    }
+  }
+}

--- a/api/api.csproj
+++ b/api/api.csproj
@@ -7,6 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
   </ItemGroup>
 

--- a/api/appsettings.json
+++ b/api/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "apiContext": "Server=(localdb)\\mssqllocaldb;Database=apiContext-b8cfa9a2-008e-4e03-84ad-ddc7b759bbfe;Trusted_Connection=True;MultipleActiveResultSets=true"
+  }
 }

--- a/nunit_tests/EmployeeTest.cs
+++ b/nunit_tests/EmployeeTest.cs
@@ -1,5 +1,6 @@
 using NUnit.Framework;
 using System;
+using api;
 
 namespace nunit_tests;
 


### PR DESCRIPTION
The Employee object was created through VS tools, but the namespace was not modified from "nunit_tests" to "api".